### PR TITLE
Use BitScout JSON format - send single messages on queue

### DIFF
--- a/omamqp1.conf
+++ b/omamqp1.conf
@@ -9,7 +9,7 @@ url=%AMQP_URL%
 # receive all log messages sent by omamqp1.py.  The default is
 # 'rsyslogd' unless overridden here.
 #
-target=rsyslogd
+target=bitscout
 
 # A value in seconds indicating the desired frequency of heartbeats
 # used to test the underlying socket is alive.
@@ -36,4 +36,4 @@ log-level=DEBUG
 # Send internal log messages to a file.
 #
 log-to-file=/dev/null
-
+#log-to-file=STDOUT

--- a/rsyslog.d/01-bitscout-messaging.conf
+++ b/rsyslog.d/01-bitscout-messaging.conf
@@ -1,10 +1,27 @@
-# This is basically the RSYSLOG_SyslogProtocol23Format, which is RFC 5424 on
-# the wire, but with the message payload a CEE/Lumberjack JSON document.
-template(name="BITSCOUT_SyslogProtocol23Format" type="string"
-    string="<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% %PROCID% %MSGID% %STRUCTURED-DATA% @cee:%$!%\n")
+template(name="bitscout-json-format" type="list") {
+    constant(value="{")
+    constant(value="\"@timestamp\":\"")               property(name="timereported" dateFormat="rfc3339")
+    constant(value="\",\"@version\":\"2015.09.24-0")
+    constant(value="\",\"message\":\"")               property(name="msg" format="json")
+    constant(value="\",\"hostname\":\"")              property(name="hostname")
+    constant(value="\",\"level\":\"")                 property(name="syslogseverity-text")
+    constant(value="\",\"pid\":\"")                   property(name="procid")
+    constant(value="\",\"rsyslog\": {")
+    constant(value="\"facility\":\"")                 property(name="syslogfacility-text")
+    constant(value="\",\"programname\":\"")           property(name="programname")
+    constant(value="\",\"fromhost\":\"")              property(name="fromhost")
+    constant(value="\",\"fromhost-ip\":\"")           property(name="fromhost-ip")
+    constant(value="\",\"timegenerated\":\"")         property(name="timegenerated" dateFormat="rfc3339")
+    constant(value="\",\"protocol-version\":\"")      property(name="protocol-version")
+    constant(value="\",\"structured-data\":\"")       property(name="structured-data")
+    constant(value="\",\"app-name\":\"")              property(name="app-name")
+    constant(value="\",\"msgid\":\"")                 property(name="msgid")
+    constant(value="\",\"inputname\":\"")             property(name="inputname")
+    constant(value="\"} }\n")
+    }
 
 module(load="omprog")
 
 action(type="omprog"
        binary="/opt/app-root/bin/omamqp1.py"
-       template="BITSCOUT_SyslogProtocol23Format")
+       template="bitscout-json-format")


### PR DESCRIPTION
Use the common namespace JSON format for log messages
Change the message queue writer to send each log message as a separate
JSON formatted hash rather than a list - the receiver expects
each message is a single JSON hash.
If this doesn't perform we'll have to figure out how to do batch updates.
